### PR TITLE
Add Airtable client and CLI utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.env
+secrets/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Guardamaterial Airtable Utilities
+
+This project provides a small helper package for reading Airtable credentials
+from the local `secrets` directory (or environment variables) and for fetching
+records from the Airtable REST API. A tiny CLI is included to demonstrate the
+functionality.
+
+## Usage
+
+1. Provide the Airtable credentials via environment variables or files inside a
+   secrets directory:
+
+   - `AIRTABLE_API_KEY`
+   - `AIRTABLE_BASE_ID`
+   - `AIRTABLE_DEFAULT_TABLE` (optional)
+   - `AIRTABLE_VIEW` (optional)
+
+   When using files, create a directory (default: `secrets/`) where each file
+   contains the raw secret value (e.g. `secrets/airtable_api_key`). JSON and
+   TOML files named `airtable.json` or `airtable.toml` are also supported.
+
+2. Run the CLI:
+
+   ```bash
+   python -m guardamaterial list <TABLE_NAME>
+   ```
+
+   The command prints a JSON payload with the retrieved records.
+
+## Development
+
+Install the dependencies and run the tests with:
+
+```bash
+pip install -e .[dev]
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "guardamaterial"
+version = "0.1.0"
+description = "Utilities for loading Airtable secrets and fetching records."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[project.scripts]
+guardamaterial = "guardamaterial.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-q"

--- a/src/guardamaterial/__init__.py
+++ b/src/guardamaterial/__init__.py
@@ -1,0 +1,6 @@
+"""Guardamaterial Airtable utilities."""
+
+from .config import AirtableConfig, load_config
+from .airtable import AirtableClient
+
+__all__ = ["AirtableConfig", "AirtableClient", "load_config"]

--- a/src/guardamaterial/airtable.py
+++ b/src/guardamaterial/airtable.py
@@ -1,0 +1,105 @@
+"""Simple Airtable REST API client."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from .config import AirtableConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AirtableClient:
+    """Client for interacting with Airtable."""
+
+    api_url: str = "https://api.airtable.com/v0"
+
+    def __init__(
+        self,
+        config: AirtableConfig,
+        *,
+        timeout: float = 10.0,
+    ) -> None:
+        self.config = config
+        self.timeout = timeout
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
+        query = f"?{urlencode(params, doseq=True)}" if params else ""
+        url = f"{self.api_url}/{self.config.base_id}/{path}{query}"
+        request = Request(
+            url=url,
+            method=method.upper(),
+            headers={
+                "Authorization": f"Bearer {self.config.api_key}",
+                "Accept": "application/json",
+            },
+        )
+        _LOGGER.debug("Sending %s request to %s", method, url)
+
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                data = response.read()
+                encoding = response.headers.get_content_charset("utf-8")
+                payload = json.loads(data.decode(encoding))
+                _LOGGER.debug("Received response: %s", payload)
+                return payload
+        except HTTPError as exc:  # pragma: no cover - exercise actual HTTP errors
+            message = exc.read().decode("utf-8", errors="ignore")
+            raise RuntimeError(f"Airtable request failed with status {exc.code}: {message}") from exc
+
+    def list_records(
+        self,
+        *,
+        table: Optional[str] = None,
+        view: Optional[str] = None,
+        filter_formula: Optional[str] = None,
+        fields: Optional[Iterable[str]] = None,
+        max_records: Optional[int] = None,
+        page_size: int = 100,
+    ) -> List[Mapping[str, Any]]:
+        """Return all records for the given table."""
+
+        table_name = self.config.require_table(table)
+        params: Dict[str, Any] = {"pageSize": page_size}
+        if view or self.config.view:
+            params["view"] = view or self.config.view
+        if filter_formula:
+            params["filterByFormula"] = filter_formula
+        if fields:
+            params["fields[]"] = list(fields)
+
+        records: List[Mapping[str, Any]] = []
+        offset: Optional[str] = None
+        while True:
+            if offset:
+                params["offset"] = offset
+            payload = self._request("GET", table_name, params=params)
+            records.extend(payload.get("records", []))
+            offset = payload.get("offset")
+            if not offset:
+                break
+            if max_records is not None and len(records) >= max_records:
+                break
+        if max_records is not None:
+            return records[:max_records]
+        return records
+
+    def get_record(self, record_id: str, *, table: Optional[str] = None) -> Mapping[str, Any]:
+        """Fetch a single record by its Airtable record id."""
+
+        table_name = self.config.require_table(table)
+        return self._request("GET", f"{table_name}/{record_id}")
+
+
+__all__ = ["AirtableClient"]

--- a/src/guardamaterial/cli.py
+++ b/src/guardamaterial/cli.py
@@ -1,0 +1,84 @@
+"""Command line interface for interacting with Airtable."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from .airtable import AirtableClient
+from .config import load_config
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Interact with Airtable data")
+    parser.add_argument(
+        "command",
+        choices={"list", "get"},
+        help="Operation to perform",
+    )
+    parser.add_argument(
+        "identifier",
+        nargs="?",
+        help="Table name for 'list' or record id for 'get'",
+    )
+    parser.add_argument(
+        "--view",
+        help="View to use when fetching records",
+    )
+    parser.add_argument(
+        "--max-records",
+        type=int,
+        help="Maximum number of records to return",
+    )
+    parser.add_argument(
+        "--filter",
+        dest="filter_formula",
+        help="Airtable filter formula",
+    )
+    parser.add_argument(
+        "--fields",
+        nargs="*",
+        help="Subset of fields to return",
+    )
+    return parser
+
+
+def _print_json(data: Any) -> None:
+    json.dump(data, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    config = load_config()
+    client = AirtableClient(config)
+
+    if args.command == "list":
+        table = args.identifier
+        records = client.list_records(
+            table=table,
+            view=args.view,
+            filter_formula=args.filter_formula,
+            fields=args.fields,
+            max_records=args.max_records,
+        )
+        _print_json(records)
+        return 0
+
+    if args.command == "get":
+        if not args.identifier:
+            parser.error("A record id must be provided for the 'get' command")
+        record = client.get_record(args.identifier)
+        _print_json(record)
+        return 0
+
+    parser.error("Unknown command")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/guardamaterial/config.py
+++ b/src/guardamaterial/config.py
@@ -1,0 +1,135 @@
+"""Helpers for loading Airtable configuration from secrets or the environment."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping, Optional
+
+try:  # Python 3.11 compatibility
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - only for Python <3.11
+    tomllib = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class AirtableConfig:
+    """Configuration required to communicate with Airtable."""
+
+    api_key: str
+    base_id: str
+    default_table: Optional[str] = None
+    view: Optional[str] = None
+
+    def require_table(self, table: Optional[str]) -> str:
+        """Return the provided table name or fall back to the default one."""
+
+        candidate = table or self.default_table
+        if not candidate:
+            raise ValueError(
+                "No table provided. Pass a table name explicitly or set "
+                "AIRTABLE_DEFAULT_TABLE in the secrets/environment."
+            )
+        return candidate
+
+
+def _read_text_file(path: Path) -> Optional[str]:
+    if path.exists() and path.is_file():
+        return path.read_text(encoding="utf-8").strip()
+    return None
+
+
+def _load_structured_file(path: Path) -> Mapping[str, str]:
+    if not path.exists() or not path.is_file():
+        return {}
+    if path.suffix.lower() == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+    elif path.suffix.lower() in {".toml", ".tml"} and tomllib is not None:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    else:
+        return {}
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def _candidate_filenames(key: str) -> tuple[str, ...]:
+    lower = key.lower()
+    upper = key.upper()
+    prefixed_lower = f"airtable_{lower}"
+    prefixed_upper = f"AIRTABLE_{upper}"
+    return (
+        lower,
+        upper,
+        f"{lower}.txt",
+        f"{upper}.txt",
+        prefixed_lower,
+        prefixed_upper,
+        f"{prefixed_lower}.txt",
+        f"{prefixed_upper}.txt",
+    )
+
+
+def load_config(
+    *,
+    secrets_dir: Optional[Path | str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> AirtableConfig:
+    """Load Airtable configuration.
+
+    The loader tries, in order:
+
+    1. Environment variables (``AIRTABLE_*``).
+    2. Individual secret files in ``secrets_dir`` (default: ``Path("secrets")``).
+    3. A structured file named ``airtable.json`` or ``airtable.toml``.
+    """
+
+    env_mapping: Mapping[str, str] = env or os.environ
+    resolved_dir = Path(secrets_dir or env_mapping.get("SECRETS_DIR", "secrets"))
+
+    structured_values: MutableMapping[str, str] = {}
+    for candidate in ("airtable.json", "airtable.toml"):
+        structured_values.update(_load_structured_file(resolved_dir / candidate))
+
+    def _resolve_value(name: str, *, required: bool = True) -> Optional[str]:
+        env_key = f"AIRTABLE_{name.upper()}"
+        if env_key in env_mapping:
+            return env_mapping[env_key]
+
+        structured_key_variants = {
+            name,
+            name.lower(),
+            name.upper(),
+            env_key,
+        }
+        for variant in structured_key_variants:
+            if variant in structured_values:
+                return structured_values[variant]
+
+        for filename in _candidate_filenames(name):
+            value = _read_text_file(resolved_dir / filename)
+            if value:
+                return value
+
+        if required:
+            raise RuntimeError(
+                f"Missing Airtable configuration value for '{name}'. "
+                "Set the AIRTABLE_{name.upper()} environment variable or provide "
+                "a matching secret file."
+            )
+        return None
+
+    api_key = _resolve_value("api_key")
+    base_id = _resolve_value("base_id")
+    default_table = _resolve_value("default_table", required=False)
+    view = _resolve_value("view", required=False)
+
+    return AirtableConfig(
+        api_key=api_key,
+        base_id=base_id,
+        default_table=default_table,
+        view=view,
+    )
+
+
+__all__ = ["AirtableConfig", "load_config"]

--- a/tests/test_airtable.py
+++ b/tests/test_airtable.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardamaterial.airtable import AirtableClient
+from guardamaterial.config import AirtableConfig
+
+
+@pytest.fixture
+def config() -> AirtableConfig:
+    return AirtableConfig(api_key="key", base_id="base", default_table="Table")
+
+
+def test_list_records_handles_pagination(config: AirtableConfig) -> None:
+    client = AirtableClient(config, timeout=1)
+    client._request = MagicMock(  # type: ignore[assignment]
+        side_effect=[
+            {"records": [1], "offset": "next"},
+            {"records": [2]},
+        ]
+    )
+    records = client.list_records()
+
+    assert records == [1, 2]
+    assert client._request.call_count == 2  # type: ignore[attr-defined]
+    first_call = client._request.call_args_list[0]  # type: ignore[attr-defined]
+    assert first_call.kwargs["params"]["pageSize"] == 100
+
+
+def test_list_records_respects_max_records(config: AirtableConfig) -> None:
+    client = AirtableClient(config)
+    client._request = MagicMock(  # type: ignore[assignment]
+        side_effect=[
+            {"records": [1, 2], "offset": "next"},
+            {"records": [3, 4]},
+        ]
+    )
+    records = client.list_records(max_records=3)
+
+    assert records == [1, 2, 3]
+
+
+def test_get_record_uses_record_id(config: AirtableConfig) -> None:
+    client = AirtableClient(config)
+    client._request = MagicMock(return_value={"id": "rec123"})  # type: ignore[assignment]
+    record = client.get_record("rec123")
+
+    assert record["id"] == "rec123"
+    client._request.assert_called_once_with("GET", "Table/rec123")  # type: ignore[attr-defined]
+
+
+def test_list_records_without_table_fails_when_no_default(config: AirtableConfig) -> None:
+    config_without_default = AirtableConfig(api_key="key", base_id="base")
+    client = AirtableClient(config_without_default)
+
+    with pytest.raises(ValueError):
+        client.list_records(table=None)
+
+
+def test_request_builds_url_and_headers(monkeypatch: pytest.MonkeyPatch, config: AirtableConfig) -> None:
+    client = AirtableClient(config)
+
+    response = MagicMock()
+    response.read.return_value = b"{}"
+    response.headers.get_content_charset.return_value = "utf-8"
+
+    context_manager = MagicMock()
+    context_manager.__enter__.return_value = response
+    context_manager.__exit__.return_value = False
+
+    urlopen_mock = MagicMock(return_value=context_manager)
+    monkeypatch.setattr("guardamaterial.airtable.urlopen", urlopen_mock)
+
+    payload = client._request(
+        "GET",
+        "Table",
+        params={"fields[]": ["Name"], "pageSize": 1},
+    )
+
+    assert payload == {}
+    request_obj = urlopen_mock.call_args.args[0]
+    assert "fields%5B%5D=Name" in request_obj.full_url
+    assert "pageSize=1" in request_obj.full_url
+    assert request_obj.headers["Authorization"] == "Bearer key"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from guardamaterial.config import AirtableConfig, load_config
+
+
+def test_load_config_from_env() -> None:
+    env = {
+        "AIRTABLE_API_KEY": "test-key",
+        "AIRTABLE_BASE_ID": "base123",
+        "AIRTABLE_DEFAULT_TABLE": "Table",
+        "AIRTABLE_VIEW": "Grid view",
+    }
+
+    config = load_config(env=env)
+
+    assert config == AirtableConfig(
+        api_key="test-key",
+        base_id="base123",
+        default_table="Table",
+        view="Grid view",
+    )
+
+
+def test_load_config_from_secret_files(tmp_path: Path) -> None:
+    secrets_dir = tmp_path
+    (secrets_dir / "airtable_api_key").write_text("key-123", encoding="utf-8")
+    (secrets_dir / "airtable_base_id").write_text("base-456", encoding="utf-8")
+    (secrets_dir / "airtable_default_table").write_text("Inventory", encoding="utf-8")
+
+    config = load_config(secrets_dir=secrets_dir, env={})
+
+    assert config.api_key == "key-123"
+    assert config.base_id == "base-456"
+    assert config.default_table == "Inventory"
+
+
+def test_load_config_from_json(tmp_path: Path) -> None:
+    secrets_dir = tmp_path
+    (secrets_dir / "airtable.json").write_text(
+        """
+        {
+            "api_key": "json-key",
+            "base_id": "json-base",
+            "default_table": "json-table"
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    config = load_config(secrets_dir=secrets_dir, env={})
+
+    assert config.api_key == "json-key"
+    assert config.base_id == "json-base"
+    assert config.default_table == "json-table"
+
+
+def test_missing_required_config_raises(tmp_path: Path) -> None:
+    secrets_dir = tmp_path
+    (secrets_dir / "airtable_base_id").write_text("base-456", encoding="utf-8")
+
+    with pytest.raises(RuntimeError):
+        load_config(secrets_dir=secrets_dir, env={})


### PR DESCRIPTION
## Summary
- add project metadata and pytest configuration via `pyproject.toml`
- implement Airtable configuration loader and HTTP client with a simple CLI
- document usage and secrets expectations in the README and ignore local secret artifacts
- cover the new logic with unit tests for configuration resolution and client behaviour

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e89ece1483298a88b8591ec1f649)