### PR TITLE
Fix Airtable client import for auth utils

### DIFF
--- a/inventario_escuteiros/utils/auth.py
+++ b/inventario_escuteiros/utils/auth.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 import bcrypt
 
-from airtable_client import AirtableClient
+from ..airtable_client import AirtableClient
 
 try:  # pragma: no cover - streamlit may not be available during tests
     import streamlit as st  # type: ignore


### PR DESCRIPTION
## Summary
- adjust the auth utilities module to import `AirtableClient` using a package-aware path, avoiding import errors when running the Streamlit app

## Testing
- streamlit run app.py --server.headless true

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911aa2093c0832996cff79a193a351b)