### PR TITLE
Support nested secrets for users table config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Aplicação em [Streamlit](https://streamlit.io/) para gerir o inventário das d
    AIRTABLE_BASE_ID = "app..."
    AIRTABLE_INVENTORY_TABLE = "Inventário"
    AIRTABLE_TRANSACTIONS_TABLE = "Movimentos"
+   AIRTABLE_USERS_TABLE = "Utilizadores"
    ```
 
    Também é possível utilizar uma secção dedicada:
@@ -34,9 +35,10 @@ Aplicação em [Streamlit](https://streamlit.io/) para gerir o inventário das d
    base_id = "app..."
    inventory_table = "Inventário"
    transactions_table = "Movimentos"
+   users_table = "Utilizadores"
    ```
 
-   A aplicação lê automaticamente estes valores (quer estejam numa secção `[airtable]` ou na raiz do ficheiro/variáveis de ambiente), continuando a permitir a sua edição no menu lateral.
+   A aplicação lê automaticamente estes valores (quer estejam numa secção `[airtable]` ou na raiz do ficheiro/variáveis de ambiente), continuando a permitir a sua edição no menu lateral. Para o módulo de autenticação, o nome da tabela de utilizadores pode ser personalizado através de `AIRTABLE_USERS_TABLE` ou `st.secrets["airtable"]["users_table"]`; na ausência de configuração é utilizado o nome predefinido **"Utilizadores"**.
 
 ## Execução local
 1. Instale as dependências:

--- a/inventario_escuteiros/README.md
+++ b/inventario_escuteiros/README.md
@@ -30,9 +30,20 @@ Crie o ficheiro `.streamlit/secrets.toml` com as credenciais da API do Airtable:
 ```toml
 AIRTABLE_API_KEY="chave_pessoal"
 AIRTABLE_BASE_ID="id_da_base"
+# Opcional: nome personalizado da tabela de utilizadores
+AIRTABLE_USERS_TABLE="Utilizadores"
 ```
 
 O Streamlit lê automaticamente estes valores através de `st.secrets`.
+
+Também pode organizar as credenciais numa secção `[airtable]`, utilizando chaves como `users_table` para indicar o nome da tabela de autenticação:
+
+```toml
+[airtable]
+api_key="chave_pessoal"
+base_id="id_da_base"
+users_table="Utilizadores"
+```
 
 ## ▶️ Executar localmente
 

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -1,0 +1,68 @@
+"""Tests for configuration helpers in :mod:`inventario_escuteiros.utils.auth`."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import unittest
+
+from inventario_escuteiros.utils import auth
+
+
+class _EnvVarGuard:
+    """Utility to save and restore environment variables inside tests."""
+
+    def __init__(self, *keys: str) -> None:
+        self._keys = keys
+        self._original: dict[str, str | None] = {}
+
+    def __enter__(self) -> "_EnvVarGuard":
+        for key in self._keys:
+            self._original[key] = os.environ.get(key)
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        for key, value in self._original.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+class ConfigValueTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_st = auth.st
+
+    def tearDown(self) -> None:
+        auth.st = self._original_st
+
+    def test_nested_secret_value_is_used(self) -> None:
+        """The helper should read nested secrets before falling back to other sources."""
+
+        auth.st = SimpleNamespace(secrets={"airtable": {"users_table": "CustomUsers"}})
+
+        with _EnvVarGuard(auth._USERS_TABLE_ENV):
+            os.environ.pop(auth._USERS_TABLE_ENV, None)
+            value = auth._get_config_value(
+                auth._USERS_TABLE_ENV,
+                secret_paths=(("airtable", "users_table"),),
+            )
+
+        self.assertEqual(value, "CustomUsers")
+
+    def test_env_var_used_when_secret_missing(self) -> None:
+        auth.st = SimpleNamespace(secrets={})
+
+        with _EnvVarGuard(auth._USERS_TABLE_ENV):
+            os.environ[auth._USERS_TABLE_ENV] = "EnvUsers"
+            value = auth._get_config_value(
+                auth._USERS_TABLE_ENV,
+                secret_paths=(("airtable", "users_table"),),
+            )
+
+        self.assertEqual(value, "EnvUsers")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- enhance the configuration helper to read nested Streamlit secrets before falling back to environment variables
- ensure the Airtable users table name honours the configured value and document the new options
- add unit tests covering the configuration lookup behaviour

## Testing
- python -m unittest tests/test_auth_config.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ae191d488329b849a61fce9202e6)