### PR TITLE
Support nested Airtable credentials in auth helper

### DIFF
--- a/inventario_escuteiros/utils/auth.py
+++ b/inventario_escuteiros/utils/auth.py
@@ -62,8 +62,20 @@ def _get_config_value(
 @lru_cache(maxsize=1)
 def get_airtable_credentials() -> tuple[str, str]:
     """Return the Airtable credentials, raising an error when missing."""
-    api_key = _get_config_value("AIRTABLE_API_KEY") or ""
-    base_id = _get_config_value("AIRTABLE_BASE_ID") or ""
+    api_key = (
+        _get_config_value(
+            "AIRTABLE_API_KEY",
+            secret_paths=(("airtable", "api_key"),),
+        )
+        or ""
+    )
+    base_id = (
+        _get_config_value(
+            "AIRTABLE_BASE_ID",
+            secret_paths=(("airtable", "base_id"),),
+        )
+        or ""
+    )
     if not api_key or not base_id:
         raise RuntimeError(
             "Credenciais do Airtable não configuradas. Defina AIRTABLE_API_KEY e AIRTABLE_BASE_ID "


### PR DESCRIPTION
## Summary
- prioritize nested Airtable secrets when retrieving credentials
- add regression tests covering nested and top-level Airtable secrets

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b14f7fbc8329b90ff95c8c6117e0)