### PR TITLE
Support plaintext password fallback and document migration

### DIFF
--- a/app.py
+++ b/app.py
@@ -559,9 +559,14 @@ def interface_documentacao():
               - `Notas` (Texto longo)
             - **Tabela de Utilizadores** (ex.: `Utilizadores`)
               - `Email` (Texto — um endereço por registo)
-              - `PasswordHash` (Texto — hash Bcrypt da palavra-passe)
+              - `PasswordHash` (Texto — hash Bcrypt da palavra-passe, recomendado)
+              - `Palavra-passe` (Texto — suporte temporário para migração; mantenha-o vazio após configurar os hashes)
 
             > Sugestão: adicione *views* no Airtable para destacar artigos em ruptura ou movimentos recentes.
+            > 
+            > Compatibilidade temporária: a aplicação aceita credenciais na coluna `Palavra-passe` para facilitar a migração. 
+            > Gere hashes Bcrypt para cada registo, preencha `PasswordHash` e, depois de confirmar o acesso, apague os valores 
+            > em texto simples.
             """
         )
 


### PR DESCRIPTION
## Summary
- add a configurable plaintext password fallback with warnings to the authentication helper
- document the temporary acceptance of the `Palavra-passe` column and the migration path to `PasswordHash`
- cover both bcrypt and plaintext compatibility flows with new unit tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c514cab483299e92bd3f9d830ecd)