### PR TITLE
Expand Airtable table name lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,12 +134,20 @@ def obter_configuracao() -> AirtableConfig:
             api_key=api_key,
             base_id=base_id,
             inventory_table=_ler_valor_config(
-                [["airtable", "inventory_table"], ["AIRTABLE_INVENTORY_TABLE"]],
+                [
+                    ["airtable", "inventory_table"],
+                    ["AIRTABLE_INVENTORY_TABLE"],
+                    ["inventory_table"],
+                ],
                 "AIRTABLE_INVENTORY_TABLE",
                 "Inventário",
             ),
             transactions_table=_ler_valor_config(
-                [["airtable", "transactions_table"], ["AIRTABLE_TRANSACTIONS_TABLE"]],
+                [
+                    ["airtable", "transactions_table"],
+                    ["AIRTABLE_TRANSACTIONS_TABLE"],
+                    ["transactions_table"],
+                ],
                 "AIRTABLE_TRANSACTIONS_TABLE",
                 "Movimentos",
             ),


### PR DESCRIPTION
## Summary
- allow the table name loader to read values stored at the Streamlit root level (inventory_table / transactions_table)
- keep the previous fallbacks so existing configurations continue working

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691202394ed4832996c8e42c2cb22b54)