### PR TITLE
Atualiza verificação automática da base Airtable

### DIFF
--- a/scripts/check_airtable_tables.py
+++ b/scripts/check_airtable_tables.py
@@ -15,16 +15,31 @@ from typing import Dict, Iterable
 from pyairtable import Api
 
 
+# Estrutura alinhada com a aplicação Streamlit principal (``app.py``).
 EXPECTED_FIELDS: Dict[str, set[str]] = {
-    "Secções": {"Nome"},
-    "Locais": {"Nome", "Secção"},
-    "Sublocais": {"Nome", "Local"},
-    "Caixas e Armazéns": {"Nome", "Sublocal", "Estado"},
-    "Itens": {"Nome", "Categoria", "Quantidade", "Unidade", "Descrição", "Caixa", "Contenção atual"},
-    "Movimentos": {"Item", "De", "Para", "Data", "Observações"},
-    "Auditorias": {"Caixa", "Data", "Responsável", "Resultado", "Observações", "Foto"},
-    "Inventário": {"Item", "Quantidade", "Caixa"},
-    "Utilizadores": {"Email", "PasswordHash", "Palavra-passe"},
+    "Inventário": {
+        "Artigo",
+        "Secção",
+        "Quantidade",
+        "Stock Mínimo",
+        "Localização",
+        "Notas",
+        "Atualizado em",
+    },
+    "Movimentos": {
+        "Data",
+        "Artigo",
+        "Secção",
+        "Quantidade",
+        "Responsável",
+        "Tipo",
+        "Notas",
+    },
+    "Utilizadores": {
+        "Email",
+        "PasswordHash",
+        "Palavra-passe",
+    },
 }
 
 

--- a/tests/test_check_airtable_tables.py
+++ b/tests/test_check_airtable_tables.py
@@ -1,0 +1,81 @@
+"""Testes para o verificador de tabelas do Airtable."""
+
+from scripts.check_airtable_tables import (
+    DEFAULT_EXPECTED_TABLES,
+    EXPECTED_FIELDS,
+    AirtableTablesChecker,
+)
+
+
+def test_expected_tables_match_application_domain() -> None:
+    """Validar que o conjunto de tabelas esperadas está atualizado."""
+
+    assert DEFAULT_EXPECTED_TABLES == {"Inventário", "Movimentos", "Utilizadores"}
+
+
+def test_expected_fields_for_each_table_are_defined() -> None:
+    """Garantir que os campos esperados incluem as colunas críticas usadas pela app."""
+
+    assert EXPECTED_FIELDS["Inventário"] == {
+        "Artigo",
+        "Secção",
+        "Quantidade",
+        "Stock Mínimo",
+        "Localização",
+        "Notas",
+        "Atualizado em",
+    }
+    assert EXPECTED_FIELDS["Movimentos"] == {
+        "Data",
+        "Artigo",
+        "Secção",
+        "Quantidade",
+        "Responsável",
+        "Tipo",
+        "Notas",
+    }
+    assert EXPECTED_FIELDS["Utilizadores"] == {
+        "Email",
+        "PasswordHash",
+        "Palavra-passe",
+    }
+
+
+def test_table_comparison_reports_differences() -> None:
+    """O relatório deve sinalizar tabelas e campos em falta ou inesperados."""
+
+    checker = AirtableTablesChecker(
+        api_key="key",
+        base_id="base",
+        expected_tables=DEFAULT_EXPECTED_TABLES,
+        expected_fields=EXPECTED_FIELDS,
+    )
+
+    # Simula uma base com uma tabela adicional e outra em falta.
+    checker.list_tables = lambda: {"Inventário", "Movimentos", "Extra"}  # type: ignore[assignment]
+    checker.fetch_table_fields = lambda: {
+        "Inventário": {"Artigo", "Quantidade", "Notas"},
+        "Movimentos": {
+            "Data",
+            "Artigo",
+            "Secção",
+            "Quantidade",
+            "Responsável",
+            "Tipo",
+            "Notas",
+        },
+        "Extra": {"Coluna"},
+    }  # type: ignore[assignment]
+
+    comparison = checker.compare()
+
+    assert comparison.missing_tables == {"Utilizadores"}
+    assert comparison.unexpected_tables == {"Extra"}
+
+    inventario_diff = comparison.field_differences["Inventário"]
+    assert inventario_diff.missing == {"Secção", "Stock Mínimo", "Localização", "Atualizado em"}
+    assert inventario_diff.unexpected == set()
+
+    extra_diff = comparison.field_differences["Extra"]
+    assert extra_diff.expected == set()
+    assert extra_diff.unexpected == {"Coluna"}


### PR DESCRIPTION
## Summary
- alinhei os campos esperados do script de verificação com a estrutura utilizada pela aplicação Streamlit
- adicionei testes que validam as tabelas e campos esperados, bem como o relatório de discrepâncias

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120be510808329b13e642bd5de12ff)