### PR TITLE
Handle Streamlit secrets case-insensitively for Airtable config

### DIFF
--- a/tests/test_app_metadata.py
+++ b/tests/test_app_metadata.py
@@ -3,6 +3,7 @@
 from importlib import util
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 
 def _load_app_module():
@@ -86,3 +87,27 @@ def test_base_metadata_obter_tabela_returns_none_for_unknown() -> None:
     metadata = BaseMetadata(tabelas=(TableMetadata(nome="Inventário", campos=("Artigo",)),))
 
     assert metadata.obter_tabela("Inexistente") is None
+
+
+def test_valor_secreto_supports_case_insensitive_lookup() -> None:
+    original_st = app_module.st
+    app_module.st = SimpleNamespace(secrets={"AIRTABLE": {"API_KEY": "Token-123"}})
+
+    try:
+        valor = app_module._valor_secreto(["airtable", "api_key"])
+    finally:
+        app_module.st = original_st
+
+    assert valor == "Token-123"
+
+
+def test_valor_secreto_supports_lowercase_top_level_keys() -> None:
+    original_st = app_module.st
+    app_module.st = SimpleNamespace(secrets={"airtable_base_id": "baseXYZ"})
+
+    try:
+        valor = app_module._valor_secreto(["AIRTABLE_BASE_ID"])
+    finally:
+        app_module.st = original_st
+
+    assert valor == "baseXYZ"

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -158,6 +158,23 @@ class AirtableCredentialsTests(unittest.TestCase):
 
         self.assertEqual(credentials, ("top-key", "top-base"))
 
+    def test_lowercase_secrets_are_supported(self) -> None:
+        """Secrets definidos em minúsculas devem ser aceites para compatibilidade."""
+
+        auth.st = SimpleNamespace(
+            secrets={
+                "airtable_api_key": "lower-key",
+                "airtable_base_id": "lower-base",
+            }
+        )
+
+        with _EnvVarGuard("AIRTABLE_API_KEY", "AIRTABLE_BASE_ID"):
+            os.environ.pop("AIRTABLE_API_KEY", None)
+            os.environ.pop("AIRTABLE_BASE_ID", None)
+            credentials = auth.get_airtable_credentials()
+
+        self.assertEqual(credentials, ("lower-key", "lower-base"))
+
 
 class AirtableErrorFormattingTests(unittest.TestCase):
     """Testes para o formatação de erros ao comunicar com o Airtable."""


### PR DESCRIPTION
## Summary
- normalise Streamlit secret lookups in the app and authentication helper so Airtable credentials can be read regardless of key casing
- extend the configuration helpers to cope with custom secret objects by using mapping-aware access
- add regression tests covering lowercase secret names for both the auth helper and the app sidebar metadata reader

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120d0680d08329b23c9cf29f5a5221)