### PR TITLE
Clarify Airtable permission guidance

### DIFF
--- a/app.py
+++ b/app.py
@@ -292,7 +292,10 @@ def _formatar_erro_airtable(exc: Exception, config: AirtableConfig) -> str:
             f"('{config.base_id}') e se as tabelas '{config.inventory_table}' e "
             f"'{config.transactions_table}' existem com estes nomes. "
             "Pode ajustar os nomes na barra lateral ou através das variáveis "
-            "AIRTABLE_INVENTORY_TABLE e AIRTABLE_TRANSACTIONS_TABLE."
+            "AIRTABLE_INVENTORY_TABLE e AIRTABLE_TRANSACTIONS_TABLE. "
+            "Confirme também que o token inclui os scopes necessários "
+            "(por exemplo, `data.records:read`, `data.records:write` e "
+            "`schema.bases:read`)."
         )
     elif status_code == 401:
         partes.append(

--- a/tests/test_app_metadata.py
+++ b/tests/test_app_metadata.py
@@ -189,6 +189,7 @@ def test_formatar_erro_airtable_inclui_dica_para_tabelas() -> None:
 
     assert "tabelas 'Inventário' e 'Movimentos'" in mensagem
     assert "Detalhe técnico: 403 Client Error" in mensagem
+    assert "data.records:read" in mensagem
 
 
 def test_formatar_erro_airtable_utiliza_payload_error_aninhado() -> None:


### PR DESCRIPTION
## Summary
- extend the Airtable permission error hint to reference required API scopes alongside table name guidance
- update the metadata formatting test to assert the new scope guidance

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121822c074832988fb074352fdb519)