### PR TITLE
Add demo CSV fallback for Streamlit inventory

### DIFF
--- a/tests/test_demo_data.py
+++ b/tests/test_demo_data.py
@@ -1,0 +1,60 @@
+"""Testes para os dados de demonstração carregados a partir dos CSV locais."""
+
+import types
+
+import pandas as pd
+
+import app as app_module
+
+
+def test_carregar_inventario_demo_normaliza_colunas() -> None:
+    inventario = app_module.carregar_inventario_demo()
+
+    assert list(inventario.columns) == [
+        "id",
+        "Artigo",
+        "Secção",
+        "Quantidade",
+        "Stock Mínimo",
+        "Localização",
+        "Notas",
+        "Atualizado",
+    ]
+    assert not inventario.empty
+    assert inventario.iloc[0]["Artigo"] == "Cominhos"
+    assert inventario["Quantidade"].dtype == int
+
+
+def test_carregar_movimentos_demo_normaliza_quantidades() -> None:
+    movimentos = app_module.carregar_movimentos_demo()
+
+    assert set(movimentos.columns) == {
+        "id",
+        "Data",
+        "Artigo",
+        "Secção",
+        "Quantidade",
+        "Responsável",
+        "Tipo",
+        "Notas",
+    }
+    assert movimentos.iloc[0]["Quantidade"] == 1
+    assert movimentos["Data"].notna().all()
+
+
+def test_guardar_metadados_demo_atualiza_session_state(monkeypatch) -> None:
+    fake_state: dict[str, object] = {}
+    fake_st = types.SimpleNamespace(session_state=fake_state)
+
+    original_st = app_module.st
+    app_module.st = fake_st
+    try:
+        app_module._guardar_metadados_demo(
+            pd.DataFrame({"Artigo": ["Exemplo"], "Quantidade": [1]}),
+            pd.DataFrame({"Artigo": ["Exemplo"], "Quantidade": [1]}),
+        )
+    finally:
+        app_module.st = original_st
+
+    assert "_airtable_metadata" in fake_state
+    assert "_airtable_metadata_error" in fake_state


### PR DESCRIPTION
## Summary
- add a data source toggle that enables using bundled CSV exports as a demo data source when Airtable access is unavailable
- normalize the demo CSV files into the same schema used by the app, expose a read-only mode in the inventory and movements tabs, and surface metadata for the sample data
- cover the new demo loaders and metadata helper with unit tests

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219838d0608329b6d1e95ffeb1c9da)