### PR TITLE
Add Streamlit secrets fallback for Airtable credentials

### DIFF
--- a/tests/test_airtable_client_module.py
+++ b/tests/test_airtable_client_module.py
@@ -41,6 +41,19 @@ def test_obter_credenciais_do_ambiente(monkeypatch: pytest.MonkeyPatch) -> None:
     assert airtable_client.obter_credenciais_do_ambiente() == ("key123", "base123")
 
 
+def test_obter_credenciais_do_ambiente_com_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(airtable_client.ENV_API_KEY, raising=False)
+    monkeypatch.delenv(airtable_client.ENV_BASE_ID, raising=False)
+    monkeypatch.setattr(
+        airtable_client.st,
+        "secrets",
+        {"AIRTABLE_API_KEY": "secret_key", "AIRTABLE_BASE_ID": "secret_base"},
+        raising=False,
+    )
+
+    assert airtable_client.obter_credenciais_do_ambiente() == ("secret_key", "secret_base")
+
+
 def test_obter_credenciais_do_ambiente_erro(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(airtable_client.ENV_API_KEY, raising=False)
     monkeypatch.delenv(airtable_client.ENV_BASE_ID, raising=False)


### PR DESCRIPTION
## Summary
- allow Airtable clients to read Airtable credentials from Streamlit `st.secrets` in addition to environment variables
- make credential lookups resilient to missing secrets files and improve messaging
- add test coverage for secrets-based configuration

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219f88409c8329ac5eb62108931dad)