### PR TITLE
Handle Airtable metadata permission errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -273,11 +273,22 @@ def _parse_metadata_tables(response: object) -> BaseMetadata:
 def _formatar_erro_metadados(exc: Exception, base_id: str) -> RuntimeError:
     """Gera uma mensagem de erro amigável ao falhar a leitura de metadados."""
 
+    status_code, error_type, detalhes_exc = _detalhes_erro_airtable(exc)
+
+    if error_type == "INVALID_PERMISSION_OR_VIEW_NOT_AVAILABLE":
+        mensagem = (
+            "O token configurado não tem permissões para ler a estrutura das tabelas via API de metadados. "
+            "Ative o scope 'schema.bases:read' no token ou ignore este aviso e indique manualmente as tabelas na barra lateral."
+        )
+        sufixo_http = f" (HTTP {status_code})" if status_code else ""
+        detalhes_limpos = f" Detalhe técnico: {detalhes_exc.strip()}" if detalhes_exc.strip() else ""
+        return RuntimeError(f"{mensagem}{sufixo_http}{detalhes_limpos} (base: {base_id}).")
+
     mensagem = (
         "Não foi possível obter automaticamente a lista de tabelas do Airtable. "
         "Confirme se a chave tem o scope 'schema.bases.read' e se a base está acessível."
     )
-    detalhes = str(exc).strip()
+    detalhes = detalhes_exc.strip()
     if detalhes:
         mensagem = f"{mensagem} (base: {base_id}). Detalhe técnico: {detalhes}"
     else:

--- a/tests/test_app_metadata.py
+++ b/tests/test_app_metadata.py
@@ -31,6 +31,7 @@ AirtableConfig = app_module.AirtableConfig
 _parse_metadata_tables = app_module._parse_metadata_tables
 _build_airtable_metadata_url = app_module._build_airtable_metadata_url
 _request_airtable_metadata = app_module._request_airtable_metadata
+_formatar_erro_metadados = app_module._formatar_erro_metadados
 _formatar_erro_airtable = app_module._formatar_erro_airtable
 
 
@@ -171,6 +172,27 @@ class _DummyAirtableException(Exception):
         super().__init__(message)
         self.response = response
         self.error = error
+
+
+def test_formatar_erro_metadados_refere_scope_quando_sem_permissoes() -> None:
+    exc = _DummyAirtableException(
+        "Live Table Metadata: Missing access",
+        response=_DummyResponse(
+            403,
+            {
+                "error": {
+                    "type": "INVALID_PERMISSION_OR_VIEW_NOT_AVAILABLE",
+                    "message": "missing_required_permission: schema",  # exemplo similar ao Airtable
+                }
+            },
+        ),
+    )
+
+    mensagem = str(_formatar_erro_metadados(exc, "baseXYZ"))
+
+    assert "não tem permissões" in mensagem
+    assert "schema.bases:read" in mensagem
+    assert "baseXYZ" in mensagem
 
 
 def test_formatar_erro_airtable_inclui_dica_para_tabelas() -> None:


### PR DESCRIPTION
## Summary
- Improve metadata error handling to explain missing schema permissions and suggest manual table entry
- Add regression test covering metadata permission error messaging

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921a2cac7e483298e7a41f0c43af3c3)